### PR TITLE
Enable booting from LVM2 in the initrd

### DIFF
--- a/systems/sputnik/disks.nix
+++ b/systems/sputnik/disks.nix
@@ -94,6 +94,8 @@
     };
   };
 
+  boot.initrd.services.lvm.enable = true;
+
   boot.initrd.systemd.services.rollback = {
     description = "Rollback BTRFS root subvolume to a pristine state";
     unitConfig.DefaultDependencies = "no";


### PR DESCRIPTION
> I haven't been able to reply to our conversation since yesterday, whenever I try to send a message it systematically fails with error "You cannot perform the action", so I'm opening a PR here instead…

I stumbled across this Discourse thread: https://discourse.nixos.org/t/devices-not-visable-using-initrd-systemd-with-btrfs/42871, in which IogaMaster is trying to do the exact same thing as you are: same setup, same script, same issue.

Enabling booting from LVM2 in the initrd with `boot.initrd.services.lvm.enable = true`, as suggested in the first answer by ElvishJerricco, fixes the issue for me, could you try this on your machine?